### PR TITLE
feat(manager/balance): fiat withdrawals 

### DIFF
--- a/src/db/selectors/BITPANDA/index.ts
+++ b/src/db/selectors/BITPANDA/index.ts
@@ -1,5 +1,7 @@
 import * as depositsSelectors from "./deposits";
+import * as withdrawalsSelectors from "./withdrawal";
 
 export const selectors = {
   deposits: depositsSelectors,
+  withdrawals: withdrawalsSelectors,
 };

--- a/src/db/selectors/BITPANDA/withdrawal.ts
+++ b/src/db/selectors/BITPANDA/withdrawal.ts
@@ -1,0 +1,37 @@
+import { PrismaClient, BitpandaTrade, PrismaPromise } from "@prisma/client";
+
+/*
+ * Bitpanda support only fiat EUR deposits so
+ * it's harcoded here
+ */
+export const getFiat = (
+  prisma: PrismaClient,
+  options?: Partial<{
+    timestamp: Partial<{
+      gte: Date;
+      lte: Date;
+    }>;
+  }>
+): PrismaPromise<BitpandaTrade[]> => {
+  return prisma.bitpandaTrade.findMany({
+    where: {
+      AND: [
+        { transactionType: "withdrawal" },
+        { assetClass: "Fiat" },
+        { fiat: "EUR" },
+        { amountFiat: { gt: 0 } },
+        { inOut: "outgoing" },
+        {
+          timestamp: {
+            gte: new Date(
+              options?.timestamp?.gte ?? "2021-01-01"
+            ).toISOString(),
+            lte: new Date(
+              options?.timestamp?.lte ?? "2022-12-31"
+            ).toISOString(),
+          },
+        },
+      ],
+    },
+  });
+};

--- a/src/db/selectors/CRYPTO_COM_APP/index.ts
+++ b/src/db/selectors/CRYPTO_COM_APP/index.ts
@@ -1,5 +1,6 @@
 import * as depositsSelectors from "./deposits";
-
+import * as withdrawalsSelectors from "./withdrawal";
 export const selectors = {
   deposits: depositsSelectors,
+  withdrawals: withdrawalsSelectors,
 };

--- a/src/db/selectors/CRYPTO_COM_APP/withdrawal.ts
+++ b/src/db/selectors/CRYPTO_COM_APP/withdrawal.ts
@@ -1,0 +1,33 @@
+import { PrismaClient } from "@prisma/client";
+
+export const getAllFiat = (
+  prisma: PrismaClient,
+  options?: Partial<{
+    timestampUtc: Partial<{
+      gte: Date;
+      lte: Date;
+    }>;
+  }>
+) => {
+  return prisma.cryptoComFiatTransaction.findMany({
+    where: {
+      AND: [
+        { currency: "EUR" },
+        {
+          transactionKind: "viban_card_top_up",
+        },
+        {
+          timestampUtc: {
+            gte: new Date(
+              options?.timestampUtc?.gte ?? "2021-01-01"
+            ).toISOString(),
+            lte: new Date(
+              options?.timestampUtc?.lte ?? "2022-12-31"
+            ).toISOString(),
+          },
+        },
+      ],
+    },
+    orderBy: { timestampUtc: "asc" },
+  });
+};

--- a/src/db/selectors/YOUNG_PLATFORM/withdrawals.ts
+++ b/src/db/selectors/YOUNG_PLATFORM/withdrawals.ts
@@ -14,3 +14,29 @@ export const getAll = (
     orderBy: { date: "asc" },
   });
 };
+
+export const getAllFiat = (
+  prisma: PrismaClient,
+  options?: Partial<{
+    date: Partial<{
+      gte: Date;
+      lte: Date;
+    }>;
+  }>
+): PrismaPromise<YoungPlatformMovement[]> => {
+  return prisma.youngPlatformMovement.findMany({
+    where: {
+      AND: [
+        { txType: "WITHDRAWAL" },
+        { currency: "EUR" },
+        {
+          date: {
+            gte: new Date(options?.date?.gte ?? "2021-01-01").toISOString(),
+            lte: new Date(options?.date?.lte ?? "2022-12-31").toISOString(),
+          },
+        },
+      ],
+    },
+    orderBy: { date: "asc" },
+  });
+};

--- a/src/manager/balance/fiatWithdraw.ts
+++ b/src/manager/balance/fiatWithdraw.ts
@@ -1,0 +1,76 @@
+import { PrismaClient } from "@prisma/client";
+import { database } from "../../db";
+
+/*
+ * This functions just retrieves funds withdrawal
+ * from an exchange account and does not cover selling to fiat
+ * that is another operation
+ */
+export const getFiatWithdrawalOperationsTotal = async (): Promise<{
+  account: Record<string, number>;
+  total: number;
+}> => {
+  const prisma = new PrismaClient();
+  /*
+   * Bitpanda support only fiat EUR withdrawals
+   * and they can be done in two ways:
+   * - card withdrawal
+   * - bank withdrawal
+   */
+  const bitpanda = (
+    await database.selectors.bitpanda.withdrawals.getFiat(prisma)
+  ).reduce((acc, curr) => acc + curr.amountFiat, 0);
+  /*
+   * Bitpanda Pro doesn't support fiat withdrawals
+   * You can only move fiat to bitpanda base account
+   */
+  const bitpandaPro = 0;
+
+  /*
+   * Nexo doesn't support fiat withdrawals in practice.
+   * It actually lets you convert EUR to EURX on deposit
+   * and if directly sell EURX without any third currency involved
+   * in that case so it's a not taxable event
+   * since 1 EURX = 1 EUR at all times so no loss/gain
+   */
+  const nexo = 0;
+  /*
+   * Crypto.com App supports fiat withdrawals through card
+   * at least i've never used bank transfer
+   * many of the total amount are actually just a bank EUR top up
+   * being transferred to the card, this does not calculate this
+   */
+  const cryptoComApp = (
+    await database.selectors.cryptoComApp.withdrawals.getAllFiat(prisma)
+  ).reduce((acc, curr) => acc + curr.amount, 0);
+
+  /*
+   * no withdraw on Crypto.com exchange
+   * just a placeholder for me to remember
+   */
+  const cryptoComExchange = 0;
+
+  const youngPlatform = (
+    await database.selectors.youngPlatform.withdrawals.getAllFiat(prisma)
+  ).reduce((acc, curr) => acc + curr.credit, 0);
+
+  return {
+    account: {
+      bitpanda,
+      bitpandaPro,
+      nexo,
+      cryptoComApp,
+      cryptoComExchange,
+      youngPlatform,
+    },
+    total:
+      cryptoComExchange +
+      bitpanda +
+      bitpandaPro +
+      nexo +
+      cryptoComApp +
+      youngPlatform,
+  };
+};
+
+getFiatWithdrawalOperationsTotal().then(console.log);


### PR DESCRIPTION
This adds selectors with date filter for fiat withdrawals.
This just takes in account EUR outflows.
Cashout is a different concept ( a sell crypto to EUR is a cashout itself and is taxable).
