### PR TITLE
feat(manager/balance): add per year filter in invested fiat balance calculation

### DIFF
--- a/src/db/selectors/BITPANDA/deposits.ts
+++ b/src/db/selectors/BITPANDA/deposits.ts
@@ -1,9 +1,6 @@
-import {
-  PrismaClient,
-  BitpandaTrade,
-  Prisma,
-  PrismaPromise,
-} from "@prisma/client";
+import { PrismaClient, BitpandaTrade, PrismaPromise } from "@prisma/client";
+import { DepositQueryConfig } from "../types";
+import { queryUtils } from "../utils";
 
 export const getAll = (
   prisma: PrismaClient
@@ -17,15 +14,17 @@ export const getAll = (
  * it's harcoded here
  */
 export const getFiat = (
-  prisma: PrismaClient
+  prisma: PrismaClient,
+  { timestamp }: Omit<DepositQueryConfig, "currency">
 ): PrismaPromise<BitpandaTrade[]> => {
   return prisma.bitpandaTrade.findMany({
     where: {
-      AND: [
-        { transactionType: "deposit" },
-        { assetClass: "Fiat" },
-        { fiat: "EUR" },
-      ],
+      transactionType: "deposit",
+      assetClass: "Fiat",
+      fiat: "EUR",
+      ...(timestamp
+        ? { timestamp: queryUtils.getTimespanQueryObject(timestamp) }
+        : {}),
     },
   });
 };

--- a/src/db/selectors/CRYPTO_COM_APP/deposits.ts
+++ b/src/db/selectors/CRYPTO_COM_APP/deposits.ts
@@ -5,30 +5,43 @@ import {
   CurrencyName,
   PrismaPromise,
 } from "@prisma/client";
+import { DepositQueryConfig } from "../types";
+import { queryUtils } from "../utils";
 
 export const getAllFiat = (
-  prisma: PrismaClient
+  prisma: PrismaClient,
+  { timestamp }: Pick<DepositQueryConfig, "timestamp">
 ): PrismaPromise<CryptoComFiatTransaction[]> => {
   return prisma.cryptoComFiatTransaction.findMany({
     where: {
-      AND: [
-        { transactionKind: { in: ["viban_card_top_up", "viban_deposit"] } },
-        { currency: "EUR" },
-        { toCurrency: "EUR" },
-        { nativeCurrency: "EUR" },
-      ],
+      transactionKind: { in: ["viban_card_top_up", "viban_deposit"] },
+      currency: "EUR",
+      toCurrency: "EUR",
+      nativeCurrency: "EUR",
+      ...(timestamp
+        ? { timestampUtc: queryUtils.getTimespanQueryObject(timestamp) }
+        : {}),
     },
   });
 };
 
 export const getAllByCrypto = (
   prisma: PrismaClient,
-  currency: Exclude<CurrencyName, "USD" | "EUR">
+  {
+    currency,
+    timestamp,
+  }: {
+    currency: Exclude<CurrencyName, "USD" | "EUR">;
+  } & Pick<DepositQueryConfig, "timestamp">
 ): PrismaPromise<CryptoComCryptoTransaction[]> => {
   {
     return prisma.cryptoComCryptoTransaction.findMany({
       where: {
-        AND: [{ transactionKind: "crypto_deposit" }, { currency: currency }],
+        transactionKind: "crypto_deposit",
+        currency: currency,
+        ...(timestamp
+          ? { timestampUtc: queryUtils.getTimespanQueryObject(timestamp) }
+          : {}),
       },
     });
   }

--- a/src/db/selectors/NEXO/deposits.ts
+++ b/src/db/selectors/NEXO/deposits.ts
@@ -4,33 +4,43 @@ import {
   CurrencyName,
   PrismaPromise,
 } from "@prisma/client";
+import { DepositQueryConfig } from "../types";
+import { queryUtils } from "../utils";
 
 export const getAllFiat = (
-  prisma: PrismaClient
+  prisma: PrismaClient,
+  { timestamp }: Pick<DepositQueryConfig, "timestamp">
 ): PrismaPromise<NexoTransaction[]> => {
   return prisma.nexoTransaction.findMany({
     where: {
-      AND: [
-        { type: "DepositToExchange" },
-        { inputCurrency: "EUR" },
-        { outputCurrency: "EURX" },
-      ],
+      type: "DepositToExchange",
+      inputCurrency: "EUR",
+      outputCurrency: "EURX",
+      ...(timestamp
+        ? { dateTime: queryUtils.getTimespanQueryObject(timestamp) }
+        : {}),
     },
   });
 };
 
 export const getAllByCrypto = (
   prisma: PrismaClient,
-  currency: Exclude<CurrencyName, "USD" | "EUR">
+  {
+    currency,
+    timestamp,
+  }: {
+    currency: Exclude<CurrencyName, "USD" | "EUR">;
+  } & Pick<DepositQueryConfig, "timestamp">
 ): PrismaPromise<NexoTransaction[]> => {
   {
     return prisma.nexoTransaction.findMany({
       where: {
-        AND: [
-          { type: "TransferIn" },
-          { inputCurrency: currency },
-          { outputCurrency: currency },
-        ],
+        type: "TransferIn",
+        inputCurrency: currency,
+        outputCurrency: currency,
+        ...(timestamp
+          ? { dateTime: queryUtils.getTimespanQueryObject(timestamp) }
+          : {}),
       },
     });
   }

--- a/src/db/selectors/YOUNG_PLATFORM/deposits.ts
+++ b/src/db/selectors/YOUNG_PLATFORM/deposits.ts
@@ -3,6 +3,8 @@ import {
   PrismaPromise,
   YoungPlatformMovement,
 } from "@prisma/client";
+import { DepositQueryConfig } from "../types";
+import { queryUtils } from "../utils";
 
 export const getAll = (
   prisma: PrismaClient
@@ -13,11 +15,16 @@ export const getAll = (
 };
 
 export const getAllFiat = (
-  prisma: PrismaClient
+  prisma: PrismaClient,
+  { timestamp }: Pick<DepositQueryConfig, "timestamp">
 ): PrismaPromise<YoungPlatformMovement[]> => {
   return prisma.youngPlatformMovement.findMany({
     where: {
-      AND: [{ txType: "DEPOSIT" }, { currency: "EUR" }],
+      txType: "DEPOSIT",
+      currency: "EUR",
+      ...(timestamp
+        ? { date: queryUtils.getTimespanQueryObject(timestamp) }
+        : {}),
     },
   });
 };

--- a/src/db/selectors/types.ts
+++ b/src/db/selectors/types.ts
@@ -10,6 +10,6 @@ export type TradeQueryConfig = {
 };
 
 export type DepositQueryConfig = {
-  currency: CurrencyName | "*";
+  currency: CurrencyName;
   timestamp?: Partial<QueryTimespan>;
 };

--- a/src/db/selectors/types.ts
+++ b/src/db/selectors/types.ts
@@ -8,3 +8,8 @@ export type TradeQueryConfig = {
   side: "buy" | "sell";
   timestamp?: Partial<QueryTimespan>;
 };
+
+export type DepositQueryConfig = {
+  currency: CurrencyName | "*";
+  timestamp?: Partial<QueryTimespan>;
+};

--- a/src/manager/balance/fiat.ts
+++ b/src/manager/balance/fiat.ts
@@ -29,7 +29,9 @@ export const getFiatDepositOperationsTotal = async (
   ).reduce((acc, curr) => acc + curr.inputAmount, 0);
 
   const cryptoComApp = (
-    await database.selectors.cryptoComApp.deposits.getAllFiat(prisma)
+    await database.selectors.cryptoComApp.deposits.getAllFiat(prisma, {
+      timestamp,
+    })
   ).reduce((acc, curr) => acc + curr.toAmount, 0);
 
   const youngPlatform = (

--- a/src/manager/balance/fiat.ts
+++ b/src/manager/balance/fiat.ts
@@ -21,7 +21,7 @@ export const getFiatDepositOperationsTotal = async (
   ).reduce((acc, curr) => acc + curr.amountFiat - (curr.fee || 0), 0);
 
   const bitpandaPro = (
-    await database.selectors.bitpandaPro.deposits.getAllFiat(prisma)
+    await database.selectors.bitpandaPro.deposits.getFiat(prisma, { timestamp })
   ).reduce((acc, curr) => acc + curr.amount - curr.fee, 0);
 
   const nexo = (

--- a/src/manager/balance/fiat.ts
+++ b/src/manager/balance/fiat.ts
@@ -35,7 +35,9 @@ export const getFiatDepositOperationsTotal = async (
   ).reduce((acc, curr) => acc + curr.toAmount, 0);
 
   const youngPlatform = (
-    await database.selectors.youngPlatform.deposits.getAllFiat(prisma)
+    await database.selectors.youngPlatform.deposits.getAllFiat(prisma, {
+      timestamp,
+    })
   ).reduce((acc, curr) => acc + curr.credit, 0);
 
   return {

--- a/src/manager/balance/fiat.ts
+++ b/src/manager/balance/fiat.ts
@@ -1,14 +1,23 @@
 import { PrismaClient } from "@prisma/client";
 import { database } from "../../db";
+import { QueryTimespan } from "../../db/selectors/utils";
 
-export const getFiatDepositOperationsTotal = async (): Promise<{
+type FiatDepositConfig = {
+  timestamp?: Partial<QueryTimespan>;
+};
+
+export const getFiatDepositOperationsTotal = async (
+  config: FiatDepositConfig
+): Promise<{
   account: Record<string, number>;
   total: number;
+  config: FiatDepositConfig;
 }> => {
+  const { timestamp } = config;
   const prisma = new PrismaClient();
 
   const bitpanda = (
-    await database.selectors.bitpanda.deposits.getAll(prisma)
+    await database.selectors.bitpanda.deposits.getFiat(prisma, { timestamp })
   ).reduce((acc, curr) => acc + curr.amountFiat - (curr.fee || 0), 0);
 
   const bitpandaPro = (
@@ -36,7 +45,10 @@ export const getFiatDepositOperationsTotal = async (): Promise<{
       youngPlatform,
     },
     total: bitpanda + bitpandaPro + nexo + cryptoComApp + youngPlatform,
+    config,
   };
 };
 
-getFiatDepositOperationsTotal().then(console.log);
+getFiatDepositOperationsTotal({
+  timestamp: { gte: "2022-01-01", lte: "2022-12-31" },
+}).then(console.log);

--- a/src/manager/balance/fiat.ts
+++ b/src/manager/balance/fiat.ts
@@ -25,7 +25,7 @@ export const getFiatDepositOperationsTotal = async (
   ).reduce((acc, curr) => acc + curr.amount - curr.fee, 0);
 
   const nexo = (
-    await database.selectors.nexo.deposits.getAllFiat(prisma)
+    await database.selectors.nexo.deposits.getAllFiat(prisma, { timestamp })
   ).reduce((acc, curr) => acc + curr.inputAmount, 0);
 
   const cryptoComApp = (

--- a/src/manager/trade/sell.ts
+++ b/src/manager/trade/sell.ts
@@ -49,7 +49,7 @@ export const getSellToFiatOperations = async (
       timestamp,
     })
   ).reduce((acc, curr) => {
-    const amount = +!curr.toAmount;
+    const amount = +curr.toAmount!;
     if (Number.isNaN(amount)) {
       throw new Error(`NaN crypto com app entry: ${JSON.stringify(curr)}`);
     }


### PR DESCRIPTION
Closes #11 

**WHAT IS IN THIS PR**

This introduces a db deposits query config and applies it to every deposit util to consequently reach the possibility to filter by timespan in the manager.

Also features a major bug fix on [crypto.com app calculation](https://github.com/silvicardo/exchanges-transactions/commit/18a58b01b8364c350b270efafc80112f5bc8de2e)