### PR TITLE
fix(db/selectors): consider external deposit only in bitpanda pro

### DIFF
--- a/src/db/selectors/BITPANDA_PRO/deposits.ts
+++ b/src/db/selectors/BITPANDA_PRO/deposits.ts
@@ -16,6 +16,7 @@ export const getAllByCurrency = (
     where: {
       type: "Deposit",
       inOut: "Incoming",
+      internalExternal: "External",
       currency: currency,
       ...(timestamp
         ? { timeCreated: queryUtils.getTimespanQueryObject(timestamp) }


### PR DESCRIPTION
**WHAT IS IN THIS PR**

Bitpanda Pro calculation was including both external and internal deposits which is unwanted since considering internal results in a duplicate bitpanda ecosystem deposit.
This change excludes such internal deposits.