### PR TITLE
feat(db/selectors): apply config to all queries

### DIFF
--- a/src/db/selectors/BITPANDA/deposits.ts
+++ b/src/db/selectors/BITPANDA/deposits.ts
@@ -3,9 +3,18 @@ import { DepositQueryConfig } from "../types";
 import { queryUtils } from "../utils";
 import prisma from "../../../../client";
 
-export const getAll = (): PrismaPromise<BitpandaTrade[]> => {
+export const getAll = ({
+  timestamp,
+}: Omit<DepositQueryConfig, "currency"> = {}): PrismaPromise<
+  BitpandaTrade[]
+> => {
   return prisma.bitpandaTrade.findMany({
-    where: { transactionType: "deposit" },
+    where: {
+      transactionType: "deposit",
+      ...(timestamp
+        ? { timestamp: queryUtils.getTimespanQueryObject(timestamp) }
+        : {}),
+    },
   });
 };
 /*
@@ -14,7 +23,9 @@ export const getAll = (): PrismaPromise<BitpandaTrade[]> => {
  */
 export const getFiat = ({
   timestamp,
-}: Omit<DepositQueryConfig, "currency">): PrismaPromise<BitpandaTrade[]> => {
+}: Omit<DepositQueryConfig, "currency"> = {}): PrismaPromise<
+  BitpandaTrade[]
+> => {
   return prisma.bitpandaTrade.findMany({
     where: {
       transactionType: "deposit",

--- a/src/db/selectors/BITPANDA/withdrawal.ts
+++ b/src/db/selectors/BITPANDA/withdrawal.ts
@@ -1,37 +1,26 @@
 import { BitpandaTrade, PrismaPromise } from "@prisma/client";
 import prisma from "../../../../client";
+import { QueryTimespan, queryUtils } from "../utils";
 
 /*
  * Bitpanda support only fiat EUR deposits so
  * it's harcoded here
  */
-export const getFiat = (
-  options?: Partial<{
-    timestamp: Partial<{
-      gte: Date;
-      lte: Date;
-    }>;
-  }>
-): PrismaPromise<BitpandaTrade[]> => {
+export const getFiat = ({
+  timestamp,
+}: Partial<{
+  timestamp: Partial<QueryTimespan>;
+}> = {}): PrismaPromise<BitpandaTrade[]> => {
   return prisma.bitpandaTrade.findMany({
     where: {
-      AND: [
-        { transactionType: "withdrawal" },
-        { assetClass: "Fiat" },
-        { fiat: "EUR" },
-        { amountFiat: { gt: 0 } },
-        { inOut: "outgoing" },
-        {
-          timestamp: {
-            gte: new Date(
-              options?.timestamp?.gte ?? "2021-01-01"
-            ).toISOString(),
-            lte: new Date(
-              options?.timestamp?.lte ?? "2022-12-31"
-            ).toISOString(),
-          },
-        },
-      ],
+      transactionType: "withdrawal",
+      assetClass: "Fiat",
+      fiat: "EUR",
+      amountFiat: { gt: 0 },
+      inOut: "outgoing",
+      ...(timestamp
+        ? { timestamp: queryUtils.getTimespanQueryObject(timestamp) }
+        : {}),
     },
   });
 };

--- a/src/db/selectors/BITPANDA_PRO/deposits.ts
+++ b/src/db/selectors/BITPANDA_PRO/deposits.ts
@@ -25,8 +25,6 @@ export const getAllByCurrency = ({
   });
 };
 
-export const getAllFiat = () => getAllByCurrency({ currency: "EUR" });
-
 export const getFiat = ({ timestamp }: Pick<DepositQueryConfig, "timestamp">) =>
   getAllByCurrency({ currency: "EUR", timestamp });
 

--- a/src/db/selectors/CRYPTO_COM_APP/withdrawal.ts
+++ b/src/db/selectors/CRYPTO_COM_APP/withdrawal.ts
@@ -1,31 +1,18 @@
 import prisma from "../../../../client";
+import { QueryTimespan, queryUtils } from "../utils";
 
-export const getAllFiat = (
-  options?: Partial<{
-    timestampUtc: Partial<{
-      gte: Date;
-      lte: Date;
-    }>;
-  }>
-) => {
+export const getAllFiat = ({
+  timestamp,
+}: Partial<{
+  timestamp: Partial<QueryTimespan>;
+}> = {}) => {
   return prisma.cryptoComFiatTransaction.findMany({
     where: {
-      AND: [
-        { currency: "EUR" },
-        {
-          transactionKind: "viban_card_top_up",
-        },
-        {
-          timestampUtc: {
-            gte: new Date(
-              options?.timestampUtc?.gte ?? "2021-01-01"
-            ).toISOString(),
-            lte: new Date(
-              options?.timestampUtc?.lte ?? "2022-12-31"
-            ).toISOString(),
-          },
-        },
-      ],
+      currency: "EUR",
+      transactionKind: "viban_card_top_up",
+      ...(timestamp
+        ? { timestampUtc: queryUtils.getTimespanQueryObject(timestamp) }
+        : {}),
     },
     orderBy: { timestampUtc: "asc" },
   });

--- a/src/db/selectors/CRYPTO_COM_EXCHANGE/deposits.ts
+++ b/src/db/selectors/CRYPTO_COM_EXCHANGE/deposits.ts
@@ -1,8 +1,18 @@
 import { CryptoComExchangeTransaction, PrismaPromise } from "@prisma/client";
 import prisma from "../../../../client";
+import { QueryTimespan, queryUtils } from "../utils";
 
-export const getAll = (): PrismaPromise<CryptoComExchangeTransaction[]> => {
+export const getAll = ({
+  timestamp,
+}: Partial<{
+  timestamp: Partial<QueryTimespan>;
+}> = {}): PrismaPromise<CryptoComExchangeTransaction[]> => {
   return prisma.cryptoComExchangeTransaction.findMany({
-    where: { transactionType: "RECEIVE" },
+    where: {
+      transactionType: "RECEIVE",
+      ...(timestamp
+        ? { transactionTime: queryUtils.getTimespanQueryObject(timestamp) }
+        : {}),
+    },
   });
 };

--- a/src/db/selectors/CRYPTO_COM_EXCHANGE/withdrawals.ts
+++ b/src/db/selectors/CRYPTO_COM_EXCHANGE/withdrawals.ts
@@ -1,8 +1,18 @@
 import { CryptoComExchangeTransaction, PrismaPromise } from "@prisma/client";
 import prisma from "../../../../client";
+import { QueryTimespan, queryUtils } from "../utils";
 
-export const getAll = (): PrismaPromise<CryptoComExchangeTransaction[]> => {
+export const getAll = ({
+  timestamp,
+}: Partial<{
+  timestamp: Partial<QueryTimespan>;
+}> = {}): PrismaPromise<CryptoComExchangeTransaction[]> => {
   return prisma.cryptoComExchangeTransaction.findMany({
-    where: { transactionType: "SEND" },
+    where: {
+      transactionType: "SEND",
+      ...(timestamp
+        ? { transactionTime: queryUtils.getTimespanQueryObject(timestamp) }
+        : {}),
+    },
   });
 };

--- a/src/db/selectors/YOUNG_PLATFORM/admin.ts
+++ b/src/db/selectors/YOUNG_PLATFORM/admin.ts
@@ -1,7 +1,17 @@
 import { PrismaPromise, YoungPlatformMovement } from "@prisma/client";
 import prisma from "../../../../client";
-export const getAll = (): PrismaPromise<YoungPlatformMovement[]> => {
+import { QueryTimespan, queryUtils } from "../utils";
+export const getAll = ({
+  timestamp,
+}: Partial<{
+  timestamp: Partial<QueryTimespan>;
+}> = {}): PrismaPromise<YoungPlatformMovement[]> => {
   return prisma.youngPlatformMovement.findMany({
-    where: { txType: "ADMIN" },
+    where: {
+      txType: "ADMIN",
+      ...(timestamp
+        ? { date: queryUtils.getTimespanQueryObject(timestamp) }
+        : {}),
+    },
   });
 };

--- a/src/db/selectors/YOUNG_PLATFORM/buy.ts
+++ b/src/db/selectors/YOUNG_PLATFORM/buy.ts
@@ -1,8 +1,18 @@
 import { PrismaPromise, YoungPlatformTrade } from "@prisma/client";
 import prisma from "../../../../client";
+import { QueryTimespan, queryUtils } from "../utils";
 
-export const getAll = (): PrismaPromise<YoungPlatformTrade[]> => {
+export const getAll = ({
+  timestamp,
+}: Partial<{
+  timestamp: Partial<QueryTimespan>;
+}> = {}): PrismaPromise<YoungPlatformTrade[]> => {
   return prisma.youngPlatformTrade.findMany({
-    where: { side: "BUY" },
+    where: {
+      side: "BUY",
+      ...(timestamp
+        ? { date: queryUtils.getTimespanQueryObject(timestamp) }
+        : {}),
+    },
   });
 };

--- a/src/db/selectors/YOUNG_PLATFORM/gift.ts
+++ b/src/db/selectors/YOUNG_PLATFORM/gift.ts
@@ -1,9 +1,17 @@
 import { PrismaPromise, YoungPlatformMovement } from "@prisma/client";
 import prisma from "../../../../client";
-export const getAll = (): PrismaPromise<YoungPlatformMovement[]> => {
+import { QueryTimespan, queryUtils } from "../utils";
+export const getAll = ({
+  timestamp,
+}: Partial<{
+  timestamp: Partial<QueryTimespan>;
+}> = {}): PrismaPromise<YoungPlatformMovement[]> => {
   return prisma.youngPlatformMovement.findMany({
     where: {
       OR: [{ txType: "GIFTCARD_STEPDROP" }, { txType: "REFERRAL" }],
+      ...(timestamp
+        ? { date: queryUtils.getTimespanQueryObject(timestamp) }
+        : {}),
     },
   });
 };

--- a/src/db/selectors/YOUNG_PLATFORM/sell.ts
+++ b/src/db/selectors/YOUNG_PLATFORM/sell.ts
@@ -1,10 +1,19 @@
 import { PrismaPromise, YoungPlatformTrade } from "@prisma/client";
 import { PairQueryInput, TradeQueryConfig } from "../types";
-import { queryUtils } from "../utils";
+import { QueryTimespan, queryUtils } from "../utils";
 import prisma from "../../../../client";
-export const getAll = (): PrismaPromise<YoungPlatformTrade[]> => {
+export const getAll = ({
+  timestamp,
+}: Partial<{
+  timestamp: Partial<QueryTimespan>;
+}> = {}): PrismaPromise<YoungPlatformTrade[]> => {
   return prisma.youngPlatformTrade.findMany({
-    where: { side: "SELL" },
+    where: {
+      side: "SELL",
+      ...(timestamp
+        ? { date: queryUtils.getTimespanQueryObject(timestamp) }
+        : {}),
+    },
   });
 };
 export const getForPair = (

--- a/src/db/selectors/YOUNG_PLATFORM/staking.ts
+++ b/src/db/selectors/YOUNG_PLATFORM/staking.ts
@@ -1,9 +1,17 @@
 import { PrismaPromise, YoungPlatformMovement } from "@prisma/client";
 import prisma from "../../../../client";
-export const getAll = (): PrismaPromise<YoungPlatformMovement[]> => {
+import { QueryTimespan, queryUtils } from "../utils";
+export const getAll = ({
+  timestamp,
+}: Partial<{
+  timestamp: Partial<QueryTimespan>;
+}> = {}): PrismaPromise<YoungPlatformMovement[]> => {
   return prisma.youngPlatformMovement.findMany({
     where: {
       OR: [{ txType: "STAKING_REWARD" }, { txType: "STAKING_TRANSACTION" }],
+      ...(timestamp
+        ? { date: queryUtils.getTimespanQueryObject(timestamp) }
+        : {}),
     },
   });
 };

--- a/src/db/selectors/YOUNG_PLATFORM/withdrawals.ts
+++ b/src/db/selectors/YOUNG_PLATFORM/withdrawals.ts
@@ -20,16 +20,12 @@ export const getAllFiat = (
 ): PrismaPromise<YoungPlatformMovement[]> => {
   return prisma.youngPlatformMovement.findMany({
     where: {
-      AND: [
-        { txType: "WITHDRAWAL" },
-        { currency: "EUR" },
-        {
-          date: {
-            gte: new Date(options?.date?.gte ?? "2021-01-01").toISOString(),
-            lte: new Date(options?.date?.lte ?? "2022-12-31").toISOString(),
-          },
-        },
-      ],
+      txType: "WITHDRAWAL",
+      currency: "EUR",
+      date: {
+        gte: new Date(options?.date?.gte ?? "2021-01-01").toISOString(),
+        lte: new Date(options?.date?.lte ?? "2022-12-31").toISOString(),
+      },
     },
     orderBy: { date: "asc" },
   });


### PR DESCRIPTION
Closes #27 

**WHAT IS IN THIS PR**

This applies not mandatory config to all db selectors.
The aim of this PR is to make every query at least configurable by a timespan.