### PR TITLE
feat(app): fiat withdrawal and deposits filtered by timestamp via query params

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@emotion/styled": "^11.11.0",
     "@prisma/client": "4.13.0",
     "@types/node": "20.3.1",
+    "@types/qs": "^6.9.7",
     "@types/react": "18.2.12",
     "@types/react-dom": "18.2.5",
     "date-fns": "^2.30.0",
@@ -56,6 +57,7 @@
     "ms": "^2.1.3",
     "next": "13.4.6",
     "papaparse": "^5.3.2",
+    "qs": "^6.11.2",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ dependencies:
   '@types/node':
     specifier: 20.3.1
     version: 20.3.1
+  '@types/qs':
+    specifier: ^6.9.7
+    version: 6.9.7
   '@types/react':
     specifier: 18.2.12
     version: 18.2.12
@@ -56,6 +59,9 @@ dependencies:
   papaparse:
     specifier: ^5.3.2
     version: 5.3.2
+  qs:
+    specifier: ^6.11.2
+    version: 6.11.2
   react:
     specifier: 18.2.0
     version: 18.2.0
@@ -2293,6 +2299,10 @@ packages:
 
   /@types/prop-types@15.7.5:
     resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}
+    dev: false
+
+  /@types/qs@6.9.7:
+    resolution: {integrity: sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==}
     dev: false
 
   /@types/react-dom@18.2.5:
@@ -4982,6 +4992,13 @@ packages:
   /pure-rand@6.0.2:
     resolution: {integrity: sha512-6Yg0ekpKICSjPswYOuC5sku/TSWaRYlA0qsXqJgM/d/4pLPHPuTxK7Nbf7jFKzAeedUhR8C7K9Uv63FBsSo8xQ==}
     dev: true
+
+  /qs@6.11.2:
+    resolution: {integrity: sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==}
+    engines: {node: '>=0.6'}
+    dependencies:
+      side-channel: 1.0.4
+    dev: false
 
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}

--- a/src/app/fiat-deposit/fiat.tsx
+++ b/src/app/fiat-deposit/fiat.tsx
@@ -25,6 +25,7 @@ export default async function Fiat({ timestamp }: Props) {
         dataKeyHead={"exchange"}
         amountSymbol={"€"}
         data={deposits.account}
+        linkSearchParams={timestamp as Record<string, string>}
       />
     </>
   );

--- a/src/app/fiat-deposit/page.tsx
+++ b/src/app/fiat-deposit/page.tsx
@@ -1,12 +1,45 @@
-import React from "react";
-import { Heading, VStack } from "@/src/components/chakra";
+import React, { Suspense } from "react";
+import {
+  Box,
+  Heading,
+  SimpleGrid,
+  Skeleton,
+  Card,
+  CardBody,
+} from "@/src/components/chakra";
 import Fiat from "@/src/app/fiat-deposit/fiat";
-import { getLastYearTimestamp } from "@/src/utils/date";
+import { getYearTimestamp } from "@/src/utils/date";
+
 export default async function Deposit() {
   return (
-    <VStack align={"flex-start"} spacing={4}>
-      <Heading>Deposits</Heading>
-      <Fiat timestamp={getLastYearTimestamp()} />
-    </VStack>
+    <Box>
+      <Heading mb={4}>Deposits</Heading>
+      <SimpleGrid
+        spacing={12}
+        templateColumns="repeat(auto-fill, minmax(400px, 1fr))"
+      >
+        <Card>
+          <CardBody>
+            <Suspense fallback={<Skeleton height={"445px"} />}>
+              <Fiat timestamp={getYearTimestamp(2021)} />
+            </Suspense>
+          </CardBody>
+        </Card>
+        <Card>
+          <CardBody>
+            <Suspense fallback={<Skeleton height={"445px"} />}>
+              <Fiat timestamp={getYearTimestamp(2022)} />
+            </Suspense>
+          </CardBody>
+        </Card>
+        <Card>
+          <CardBody>
+            <Suspense fallback={<Skeleton height={"445px"} />}>
+              <Fiat timestamp={getYearTimestamp(2023)} />
+            </Suspense>
+          </CardBody>
+        </Card>
+      </SimpleGrid>
+    </Box>
   );
 }

--- a/src/app/fiat-withdrawal/fiat.tsx
+++ b/src/app/fiat-withdrawal/fiat.tsx
@@ -25,6 +25,7 @@ export default async function Fiat({ timestamp }: Props) {
         dataKeyHead={"exchange"}
         amountSymbol={"€"}
         data={withdrawals.accounts}
+        linkSearchParams={timestamp as Record<string, string>}
       />
     </>
   );

--- a/src/app/fiat-withdrawal/page.tsx
+++ b/src/app/fiat-withdrawal/page.tsx
@@ -1,12 +1,44 @@
-import React from "react";
-import { Heading, VStack } from "@/src/components/chakra";
+import React, { Suspense } from "react";
+import {
+  Box,
+  Card,
+  CardBody,
+  Heading,
+  SimpleGrid,
+  Skeleton,
+} from "@/src/components/chakra";
 import Fiat from "@/src/app/fiat-withdrawal/fiat";
-import { getLastYearTimestamp } from "@/src/utils/date";
+import { getYearTimestamp } from "@/src/utils/date";
 export default async function Deposit() {
   return (
-    <VStack align={"flex-start"} spacing={4}>
-      <Heading>Withdrawals</Heading>
-      <Fiat timestamp={getLastYearTimestamp()} />
-    </VStack>
+    <Box>
+      <Heading mb={4}>Withdrawals</Heading>
+      <SimpleGrid
+        spacing={12}
+        templateColumns="repeat(auto-fill, minmax(400px, 1fr))"
+      >
+        <Card>
+          <CardBody>
+            <Suspense fallback={<Skeleton height={"445px"} />}>
+              <Fiat timestamp={getYearTimestamp(2021)} />
+            </Suspense>
+          </CardBody>
+        </Card>
+        <Card>
+          <CardBody>
+            <Suspense fallback={<Skeleton height={"445px"} />}>
+              <Fiat timestamp={getYearTimestamp(2022)} />
+            </Suspense>
+          </CardBody>
+        </Card>
+        <Card>
+          <CardBody>
+            <Suspense fallback={<Skeleton height={"445px"} />}>
+              <Fiat timestamp={getYearTimestamp(2023)} />
+            </Suspense>
+          </CardBody>
+        </Card>
+      </SimpleGrid>
+    </Box>
   );
 }

--- a/src/components/amounts-table/index.tsx
+++ b/src/components/amounts-table/index.tsx
@@ -12,18 +12,21 @@ import {
 } from "@chakra-ui/react";
 import { usePathname } from "next/navigation";
 import Link from "next/link";
+import qs from "qs";
 
 type Props = {
   caption: string;
   dataKeyHead: string;
   data: Record<string, number>;
   amountSymbol: string;
+  linkSearchParams?: Record<string, string>;
 };
 export default function AmountsTable({
   data,
   dataKeyHead,
   caption,
   amountSymbol,
+  linkSearchParams = {},
 }: Props) {
   const pathname = usePathname();
   return (
@@ -41,7 +44,13 @@ export default function AmountsTable({
             <Tr key={name}>
               <Td>
                 {total > 0 ? (
-                  <Link href={`${pathname}/${name}`}>{name}</Link>
+                  <Link
+                    href={`${pathname}/${name}${qs.stringify(linkSearchParams, {
+                      addQueryPrefix: true,
+                    })}`}
+                  >
+                    {name}
+                  </Link>
                 ) : (
                   name
                 )}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,8 +1,12 @@
+export const getYearTimestamp = (year: number) => {
+  return {
+    gte: new Date(`${year}-01-01`),
+    lte: new Date(`${year}-12-31`),
+  };
+};
+
 export const getLastYear = () => new Date().getFullYear() - 1;
 export const getLastYearTimestamp = () => {
   const lastYear = new Date().getFullYear() - 1;
-  return {
-    gte: new Date(lastYear + "-01-01"),
-    lte: new Date(`${lastYear}-12-31`),
-  };
+  return getYearTimestamp(lastYear);
 };


### PR DESCRIPTION
Closes #34 

**WHAT IS IN THIS PR**

Adds fiat withdrawal and deposits grouped by timestamp via query params.
Now main fiat deposit withdrawal page show a card for each year from 2021.