### PR TITLE
feat(app): coinbase import transactions 

### DIFF
--- a/prisma/migrations/20230916092825_/migration.sql
+++ b/prisma/migrations/20230916092825_/migration.sql
@@ -1,0 +1,20 @@
+-- CreateEnum
+CREATE TYPE "CoinbaseTransactionType" AS ENUM ('Buy', 'Sell', 'Learning_Reward', 'Rewards_Income');
+
+-- CreateTable
+CREATE TABLE "CoinbaseTransaction" (
+    "id" SERIAL NOT NULL,
+    "userAccountId" INTEGER NOT NULL,
+    "timestamp" TIMESTAMP(3) NOT NULL,
+    "transactionType" "CoinbaseTransactionType" NOT NULL,
+    "asset" "CurrencyName" NOT NULL,
+    "quantityTransacted" DOUBLE PRECISION NOT NULL,
+    "spotPriceCurrency" "CurrencyName" NOT NULL,
+    "spotPriceAtTransaction" DOUBLE PRECISION NOT NULL,
+    "subtotal" DOUBLE PRECISION NOT NULL,
+    "totalInclusiveOfFeesAndOrSpread" DOUBLE PRECISION NOT NULL,
+    "feesAndOrSpread" DOUBLE PRECISION NOT NULL,
+    "notes" TEXT NOT NULL,
+
+    CONSTRAINT "CoinbaseTransaction_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/migrations/20230916094650_/migration.sql
+++ b/prisma/migrations/20230916094650_/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "CoinbaseTransactionType" ADD VALUE 'Convert';

--- a/prisma/migrations/20230916095244_/migration.sql
+++ b/prisma/migrations/20230916095244_/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "CoinbaseTransaction" ALTER COLUMN "quantityTransacted" SET DATA TYPE TEXT,
+ALTER COLUMN "spotPriceAtTransaction" SET DATA TYPE TEXT,
+ALTER COLUMN "subtotal" SET DATA TYPE TEXT,
+ALTER COLUMN "totalInclusiveOfFeesAndOrSpread" SET DATA TYPE TEXT,
+ALTER COLUMN "feesAndOrSpread" SET DATA TYPE TEXT;

--- a/prisma/migrations/20230916095346_/migration.sql
+++ b/prisma/migrations/20230916095346_/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `originalData` to the `CoinbaseTransaction` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "CoinbaseTransaction" ADD COLUMN     "originalData" JSONB NOT NULL;

--- a/prisma/migrations/20230916095537_/migration.sql
+++ b/prisma/migrations/20230916095537_/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[timestamp]` on the table `CoinbaseTransaction` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "CoinbaseTransaction_timestamp_key" ON "CoinbaseTransaction"("timestamp");

--- a/prisma/migrations/20230916100053_/migration.sql
+++ b/prisma/migrations/20230916100053_/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "CurrencyName" ADD VALUE 'COMP';

--- a/prisma/migrations/20230916100243_/migration.sql
+++ b/prisma/migrations/20230916100243_/migration.sql
@@ -1,0 +1,10 @@
+-- AlterEnum
+-- This migration adds more than one value to an enum.
+-- With PostgreSQL versions 11 and earlier, this is not possible
+-- in a single migration. This can be worked around by creating
+-- multiple migrations, each migration adding only one value to
+-- the enum.
+
+
+ALTER TYPE "CurrencyName" ADD VALUE 'CGLD';
+ALTER TYPE "CurrencyName" ADD VALUE 'NU';

--- a/prisma/migrations/20230916100356_/migration.sql
+++ b/prisma/migrations/20230916100356_/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "CurrencyName" ADD VALUE 'GRT';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -113,6 +113,10 @@ enum CurrencyName {
  UST
  OP
  ARB
+ COMP
+ CGLD
+ NU
+ GRT
  SBTC
  SETH
  SAAVE
@@ -496,5 +500,29 @@ model LedgerOperation {
  countervalueAtOperationDate Float
  countervalueAtCsvExport Float
  userAccountId Int
+ originalData Json
+}
+
+enum CoinbaseTransactionType {
+ Buy
+ Sell
+ Convert
+ Learning_Reward
+ Rewards_Income
+}
+
+model CoinbaseTransaction {
+ id Int @id @default(autoincrement())
+ userAccountId Int
+ timestamp DateTime @unique
+ transactionType CoinbaseTransactionType
+ asset CurrencyName
+ quantityTransacted String
+ spotPriceCurrency CurrencyName
+ spotPriceAtTransaction String
+ subtotal String
+ totalInclusiveOfFeesAndOrSpread String
+ feesAndOrSpread String
+ notes String
  originalData Json
 }

--- a/src/app/fiat-deposit/page.tsx
+++ b/src/app/fiat-deposit/page.tsx
@@ -21,6 +21,13 @@ export default async function Deposit() {
         <Card>
           <CardBody>
             <Suspense fallback={<Skeleton height={"445px"} />}>
+              <Fiat timestamp={getYearTimestamp(2020)} />
+            </Suspense>
+          </CardBody>
+        </Card>
+        <Card>
+          <CardBody>
+            <Suspense fallback={<Skeleton height={"445px"} />}>
               <Fiat timestamp={getYearTimestamp(2021)} />
             </Suspense>
           </CardBody>

--- a/src/app/import/actions.ts
+++ b/src/app/import/actions.ts
@@ -118,6 +118,16 @@ export const importExchangeData = async (exchangeData: FormData) => {
           });
         }
         break;
+      case "COINBASE":
+        if (database.handlers.coinbase.hasOwnProperty(filename)) {
+          await database.handlers.coinbase[
+            filename as keyof typeof database.handlers.coinbase
+          ]({
+            year,
+            userAccountId: FAKE_USER_ACCOUNT_ID,
+          });
+        }
+        break;
 
       case "CRYPTO_COM_EXCHANGE":
         if (database.handlers.cryptoComExchange.hasOwnProperty(filename)) {

--- a/src/app/import/client-validation.ts
+++ b/src/app/import/client-validation.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import {
   bitpandaProSchema,
   bitpandaSchema,
+  coinbaseSchema,
   cryptoComAppSchema,
   cryptoComExchangeSchema,
   ledgerSchema,
@@ -17,4 +18,5 @@ export const clientValidationSchema = z.discriminatedUnion("exchange", [
   cryptoComAppSchema.extend({ file: z.instanceof(File) }),
   cryptoComExchangeSchema.extend({ file: z.instanceof(File) }),
   ledgerSchema.extend({ file: z.instanceof(File) }),
+  coinbaseSchema.extend({ file: z.instanceof(File) }),
 ]);

--- a/src/app/import/form-options.ts
+++ b/src/app/import/form-options.ts
@@ -7,6 +7,7 @@ export const EXCHANGE_OPTIONS = [
   "YOUNG_PLATFORM",
   "NEXO",
   "LEDGER",
+  "COINBASE",
 ] as const;
 
 export const EXCHANGE_FILENAME_OPTIONS = {
@@ -21,6 +22,7 @@ export const EXCHANGE_FILENAME_OPTIONS = {
   YOUNG_PLATFORM: ["buy_sell_swap", "deposit_withdraw_fee_order"] as const,
   NEXO: ["transactions"] as const,
   LEDGER: ["operations"] as const,
+  COINBASE: ["transactions"] as const,
 } satisfies Record<string, readonly string[]>;
 
 export type ImportFieldValues = {

--- a/src/app/import/server-validation.ts
+++ b/src/app/import/server-validation.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import {
   bitpandaProSchema,
   bitpandaSchema,
+  coinbaseSchema,
   cryptoComAppSchema,
   cryptoComExchangeSchema,
   ledgerSchema,
@@ -19,5 +20,6 @@ export const serverValidationSchema = zfd.formData(
     cryptoComAppSchema.extend({ file: z.instanceof(Blob) }),
     cryptoComExchangeSchema.extend({ file: z.instanceof(Blob) }),
     ledgerSchema.extend({ file: z.instanceof(Blob) }),
+    coinbaseSchema.extend({ file: z.instanceof(Blob) }),
   ])
 );

--- a/src/app/import/validation.ts
+++ b/src/app/import/validation.ts
@@ -48,3 +48,8 @@ export const ledgerSchema = baseSchema.extend({
   exchange: z.literal(exchangeEnum.enum.LEDGER),
   filename: z.enum(EXCHANGE_FILENAME_OPTIONS[exchangeEnum.enum.LEDGER]),
 });
+
+export const coinbaseSchema = baseSchema.extend({
+  exchange: z.literal(exchangeEnum.enum.COINBASE),
+  filename: z.enum(EXCHANGE_FILENAME_OPTIONS[exchangeEnum.enum.COINBASE]),
+});

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -65,4 +65,8 @@ export const CRYPTO_CURRENCIES: Exclude<CurrencyName, "EUR" | "USD">[] = [
   "UST",
   "OP",
   "ARB",
+  "COMP",
+  "NU",
+  "GRT",
+  "CGLD",
 ];

--- a/src/db/handlers/COINBASE/index.ts
+++ b/src/db/handlers/COINBASE/index.ts
@@ -1,0 +1,5 @@
+import { handle as handleTransactions } from "./transaction";
+
+export const handlers = {
+  transactions: handleTransactions,
+};

--- a/src/db/handlers/COINBASE/transaction.ts
+++ b/src/db/handlers/COINBASE/transaction.ts
@@ -1,0 +1,97 @@
+import { Prisma, CurrencyName, CoinbaseTransactionType } from "@prisma/client";
+import { convertCSVtoJSON } from "../../../../convertCSVtoJSON";
+import prisma from "../../../../client";
+
+export type CsvInput = {
+  Timestamp: string;
+  "Transaction Type": string;
+  Asset: CurrencyName;
+  "Quantity Transacted": number;
+  "Spot Price Currency": CurrencyName;
+  "Spot Price at Transaction": number;
+  Subtotal: number;
+  "Total (inclusive of fees and/or spread)": number;
+  "Fees and/or Spread": number;
+  Notes: string;
+};
+
+type Parsed = Omit<
+  Prisma.CoinbaseTransactionCreateInput,
+  "id" | "userAccountId" | "originalData"
+> & {
+  originalData: string;
+};
+
+const parse = (input: CsvInput): Parsed => {
+  const {
+    Timestamp: timestamp,
+    "Transaction Type": transactionType,
+    Asset: asset,
+    "Quantity Transacted": quantityTransacted,
+    "Spot Price Currency": spotPriceCurrency,
+    "Spot Price at Transaction": spotPriceAtTransaction,
+    Subtotal: subtotal,
+    "Total (inclusive of fees and/or spread)": totalInclusiveOfFeesAndOrSpread,
+    "Fees and/or Spread": feesAndOrSpread,
+    Notes: notes,
+  } = input;
+
+  return {
+    timestamp: new Date(timestamp).toISOString(),
+    transactionType: transactionType
+      .split(" ")
+      .join("_") as CoinbaseTransactionType,
+    asset,
+    quantityTransacted: String(quantityTransacted),
+    spotPriceCurrency,
+    spotPriceAtTransaction: String(spotPriceAtTransaction),
+    subtotal: String(subtotal),
+    totalInclusiveOfFeesAndOrSpread: String(totalInclusiveOfFeesAndOrSpread),
+    feesAndOrSpread: String(feesAndOrSpread),
+    notes,
+    originalData: JSON.stringify(input),
+  };
+};
+
+const store = async ({
+  parsed,
+  userAccountId,
+}: {
+  parsed: Parsed[];
+  userAccountId: number;
+}) =>
+  Promise.all(
+    parsed.map(async ({ originalData, ...trans }) => {
+      console.log("Adding Coinbase Operation > timestamp", trans.timestamp);
+      const data = {
+        ...trans,
+        originalData: [originalData] as Prisma.JsonArray,
+        userAccountId: userAccountId,
+      };
+      await prisma.coinbaseTransaction.upsert({
+        where: {
+          timestamp: trans.timestamp,
+        },
+        create: data,
+        update: data,
+      });
+      console.log("added Coinbase Operation > timestamp", trans.timestamp);
+    })
+  );
+
+export const handle = async ({
+  userAccountId,
+  year,
+}: {
+  userAccountId: number;
+  year: "2020" | "2021" | "2022" | "2023";
+}) => {
+  const csvJsonData = await convertCSVtoJSON<CsvInput>(
+    `${year}/COINBASE/transactions.csv`
+  );
+  const parsed = csvJsonData.map(parse);
+  return store({
+    parsed,
+    userAccountId,
+  });
+};

--- a/src/db/handlers/index.ts
+++ b/src/db/handlers/index.ts
@@ -4,6 +4,7 @@ import { handlers as bitpandaPro } from "./BITPANDA_PRO";
 import { handlers as bitpanda } from "./BITPANDA";
 import { handlers as nexo } from "./NEXO";
 import { handlers as ledger } from "./LEDGER";
+import { handlers as coinbase } from "./COINBASE";
 import { handlers as cryptoComExchange } from "./CRYPTO_COM_EXCHANGE";
 
 export const handlers = {
@@ -14,4 +15,5 @@ export const handlers = {
   bitpanda,
   nexo,
   ledger,
+  coinbase,
 };

--- a/src/db/selectors/COINBASE/deposits.ts
+++ b/src/db/selectors/COINBASE/deposits.ts
@@ -1,0 +1,21 @@
+import { PrismaPromise, CoinbaseTransaction } from "@prisma/client";
+import { DepositQueryConfig } from "../types";
+import { queryUtils } from "../utils";
+import prisma from "../../../../client";
+export const getAllFiat = ({
+  timestamp,
+}: Pick<DepositQueryConfig, "timestamp">): PrismaPromise<
+  CoinbaseTransaction[]
+> => {
+  return prisma.coinbaseTransaction.findMany({
+    where: {
+      transactionType: "Buy",
+      asset: {
+        notIn: ["EUR"],
+      },
+      ...(timestamp
+        ? { timestamp: queryUtils.getTimespanQueryObject(timestamp) }
+        : {}),
+    },
+  });
+};

--- a/src/db/selectors/COINBASE/index.ts
+++ b/src/db/selectors/COINBASE/index.ts
@@ -1,0 +1,5 @@
+import * as depositsSelectors from "./deposits";
+
+export const selectors = {
+  deposits: depositsSelectors,
+};

--- a/src/db/selectors/index.ts
+++ b/src/db/selectors/index.ts
@@ -5,6 +5,7 @@ import { selectors as bitpandaSelectors } from "./BITPANDA";
 import { selectors as bitpandaProSelectors } from "./BITPANDA_PRO";
 import { selectors as nexoSelectors } from "./NEXO";
 import { selectors as ledgerSelectors } from "./LEDGER";
+import { selectors as coinbaseSelectors } from "./COINBASE";
 
 export const selectors = {
   youngPlatform: youngPlatformSelectors,
@@ -14,4 +15,5 @@ export const selectors = {
   bitpandaPro: bitpandaProSelectors,
   nexo: nexoSelectors,
   ledger: ledgerSelectors,
+  coinbase: coinbaseSelectors,
 };

--- a/src/manager/balance/fiatDeposit.ts
+++ b/src/manager/balance/fiatDeposit.ts
@@ -44,6 +44,12 @@ export const getFiatDepositOperationsTotal = async (
     })
   ).reduce((acc, curr) => acc + +curr.operationAmount, 0);
 
+  const coinbase = (
+    await database.selectors.coinbase.deposits.getAllFiat({
+      timestamp,
+    })
+  ).reduce((acc, curr) => acc + +curr.totalInclusiveOfFeesAndOrSpread, 0);
+
   return {
     account: {
       bitpanda,
@@ -52,9 +58,16 @@ export const getFiatDepositOperationsTotal = async (
       cryptoComApp,
       youngPlatform,
       ledger,
+      coinbase,
     },
     total:
-      bitpanda + bitpandaPro + nexo + cryptoComApp + youngPlatform + ledger,
+      bitpanda +
+      bitpandaPro +
+      nexo +
+      cryptoComApp +
+      youngPlatform +
+      ledger +
+      coinbase,
     config,
   };
 };


### PR DESCRIPTION
Closes #54 

**WHAT IS IN THIS PR**

This adds support for Coinbase transactions report:
- csv import in db
  - prisma schema
  - db handler
- db selectors for fiat deposits
- app
  - import page coinbase option

On the side also adds fiat deposit page coinbase totals.
  